### PR TITLE
Optimistically update the UI

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -9,8 +9,8 @@
         font-weight: normal;
         font-stretch: normal;
         src: url('fonts/charter_regular.woff2') format('woff2');
-        }
-        
+    }
+
     @font-face {
         font-family: 'Charter';
         font-style: italic;
@@ -18,7 +18,7 @@
         font-stretch: normal;
         src: url('fonts/charter_italic.woff2') format('woff2');
     }
-    
+
     @font-face {
         font-family: 'Charter';
         font-style: normal;
@@ -26,7 +26,7 @@
         font-stretch: normal;
         src: url('fonts/charter_bold.woff2') format('woff2');
     }
-    
+
     @font-face {
         font-family: 'Charter';
         font-style: italic;
@@ -66,28 +66,24 @@
 
         .tooltip>.arrow {
             visibility: hidden;
-        }
 
-        .tooltip>.arrow::before {
-            visibility: visible;
-            content: '';
-            transform: rotate(45deg);
+            &::before {
+                visibility: visible;
+                content: '';
+                transform: rotate(45deg);
+            }
         }
 
         .tooltip[data-popper-placement^='top']>.arrow {
-            bottom: -7.5px;
+            bottom: -3.4px;
+
+            &::before {
+                transform: rotate(225deg);
+            }
         }
 
         .tooltip[data-popper-placement^='bottom']>.arrow {
             top: -7.5px;
-        }
-
-        .tooltip[data-popper-placement^='left']>.arrow {
-            right: -7.5px;
-        }
-
-        .tooltip[data-popper-placement^='right']>.arrow {
-            left: -7.5px;
         }
     }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -247,6 +247,7 @@ Hooks.CardButton = {
 
         if (tooltip) {
           tooltip.classList.add(borderColour);
+          tooltip.classList.remove("opacity-0");
           tooltip.tooltip.show();
           tooltip.innerHTML = `Anonymous ${avatar.split("-")[0]} (You)`;
         }
@@ -256,6 +257,8 @@ Hooks.CardButton = {
         button.classList.add("p-2");
 
         if (tooltip) {
+          tooltip.classList.remove(borderColour);
+          tooltip.classList.add("opacity-0");
           tooltip.tooltip?.hide();
         }
       }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -111,6 +111,10 @@ class Tooltip {
         this.$parent.removeEventListener(event, callback)
       );
     });
+
+    if (this.$parent.matches(':hover')) {
+      this.show();
+    }
   }
 
   // The show method adds the data-show attribute to the tooltip element,
@@ -231,6 +235,43 @@ Hooks.CardButton = {
 
     resizeObserver.observe(el);
     mutationObserver.observe(el, { childList: true });
+
+    const tooltip = this.el.querySelector('[role="tooltip"]');
+    const button = this.el;
+
+    function updateCardSelection(isSelected, colour, avatar) {
+      const borderColour = colour !== null ? colour.replace("bg-", "border-") : null;
+      if (isSelected) {
+        button.classList.add("border-4", "p-1", borderColour);
+        button.classList.remove("p-2");
+
+        if (tooltip) {
+          tooltip.classList.add(borderColour);
+          tooltip.tooltip.show();
+          tooltip.innerHTML = `Anonymous ${avatar.split("-")[0]} (You)`;
+        }
+      } else {
+        const borderClasses = Array.from(button.classList).filter(cls => cls.startsWith('border-'));
+        button.classList.remove("p-1", ...borderClasses);
+        button.classList.add("p-2");
+
+        if (tooltip) {
+          tooltip.tooltip?.hide();
+        }
+      }
+    }
+
+    this.el.addEventListener("toggle_card", ({ detail: { avatar, colour } }) => {
+      const isSelected = this.el.dataset.selected !== "true";
+
+      if (!isSelected || (isSelected && document.querySelectorAll(`button[data-selected="true"]`).length < 4)) {
+        updateCardSelection(isSelected, colour, avatar);
+      }
+    });
+
+    this.handleEvent(`update-card-${this.el.id}`, ({ selected, colour, avatar }) => {
+      updateCardSelection(selected, colour, avatar);
+    });
 
     this.handleEvent(`animate-hint-${this.el.id}`, () => {
       gsap.fromTo(this.el, { rotate: 15 }, { rotation: 0, ease: "elastic.out(1.2,0.1)", duration: 2 })

--- a/lib/connections_multiplayer_web/live/play_live.ex
+++ b/lib/connections_multiplayer_web/live/play_live.ex
@@ -223,7 +223,7 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
       |> game_state_to_map()
       |> then(&assign_game_state(socket, &1))
       |> maybe_fire_confetti(socket.assigns.found_categories.result, new_state.found_categories)
-      |> push_card_updates_to_client(new_state.cards, socket.assigns.cards.result)
+      |> push_card_updates_to_client(new_state.cards)
 
     {:noreply, socket}
   end
@@ -236,7 +236,7 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
       |> then(&assign_game_state(socket, &1))
       |> put_flash(flash_kind, message)
       |> maybe_fire_confetti(socket.assigns.found_categories.result, new_state.found_categories)
-      |> push_card_updates_to_client(new_state.cards, socket.assigns.cards.result)
+      |> push_card_updates_to_client(new_state.cards)
 
     {:noreply, socket}
   end
@@ -283,19 +283,13 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
     {:noreply, socket}
   end
 
-  defp push_card_updates_to_client(socket, new_cards, old_cards) do
-    Enum.reduce(new_cards, socket, fn {card, new_card_info}, socket ->
-      old_card_info = Map.get(old_cards, card)
-
-      if old_card_info != new_card_info do
-        push_event(socket, "update-card-#{card}", %{
-          selected: new_card_info.selected,
-          avatar: Map.get(new_card_info, :avatar),
-          colour: Map.get(new_card_info, :colour)
-        })
-      else
-        socket
-      end
+  defp push_card_updates_to_client(socket, cards) do
+    Enum.reduce(cards, socket, fn {card, card_info}, socket ->
+      push_event(socket, "update-card-#{card}", %{
+        selected: card_info.selected,
+        avatar: Map.get(card_info, :avatar),
+        colour: Map.get(card_info, :colour)
+      })
     end)
   end
 

--- a/lib/connections_multiplayer_web/live/play_live.ex
+++ b/lib/connections_multiplayer_web/live/play_live.ex
@@ -223,6 +223,15 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
       |> game_state_to_map()
       |> then(&assign_game_state(socket, &1))
       |> maybe_fire_confetti(socket.assigns.found_categories.result, new_state.found_categories)
+      |> then(
+        &Enum.reduce(new_state.cards, &1, fn {card, card_info}, socket ->
+          push_event(socket, "update-card-#{card}", %{
+            selected: card_info.selected,
+            avatar: Map.get(card_info, :avatar),
+            colour: Map.get(card_info, :colour)
+          })
+        end)
+      )
 
     {:noreply, socket}
   end
@@ -235,6 +244,15 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
       |> then(&assign_game_state(socket, &1))
       |> put_flash(flash_kind, message)
       |> maybe_fire_confetti(socket.assigns.found_categories.result, new_state.found_categories)
+      |> then(
+        &Enum.reduce(new_state.cards, &1, fn {card, card_info}, socket ->
+          push_event(socket, "update-card-#{card}", %{
+            selected: card_info.selected,
+            avatar: Map.get(card_info, :avatar),
+            colour: Map.get(card_info, :colour)
+          })
+        end)
+      )
 
     {:noreply, socket}
   end
@@ -365,9 +383,10 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
     end
   end
 
+  defp border_colour_from_bg_colour(nil), do: nil
+
   defp border_colour_from_bg_colour(colour) do
-    colour = String.replace_prefix(colour, "bg-", "")
-    "border-#{colour}"
+    String.replace_prefix(colour, "bg-", "border-")
   end
 
   defp card_button_class(params) do
@@ -395,6 +414,8 @@ defmodule ConnectionsMultiplayerWeb.PlayLive do
   defp hintable(cards) do
     !cards.ok? || is_nil(cards.result) || map_size(cards.result) > 4
   end
+
+  defp avatar_name(nil), do: nil
 
   defp avatar_name(id) do
     [name, _] = String.split(id, "-")

--- a/lib/connections_multiplayer_web/live/play_live.html.heex
+++ b/lib/connections_multiplayer_web/live/play_live.html.heex
@@ -47,8 +47,8 @@
             phx-value-card={card}
             class={card_button_class(params)}
             phx-hook="CardButton">
-            <.tooltip :if={params.selected} class={["px-4 py-2 font-medium text-black bg-card border-2 rounded-md",
-                border_colour_from_bg_colour(params[:colour])]}>
+            <.tooltip class={["px-4 py-2 font-medium text-black bg-card border-2 rounded-md",
+                border_colour_from_bg_colour(params[:colour]), !params.selected && "opacity-0" ]}>
                 Anonymous {avatar_name(params[:avatar])} {if(params[:avatar] == @avatar, do: "(You)")}
             </.tooltip>
             <p id={"card-button-text-#{card}"} class="w-full h-full flex flex-wrap content-center justify-center">{card}

--- a/lib/connections_multiplayer_web/live/play_live.html.heex
+++ b/lib/connections_multiplayer_web/live/play_live.html.heex
@@ -40,11 +40,16 @@
             </button>
         </:loading>
         <:failed>Failed to fetch cards, retry...</:failed>
-        <button phx-no-format :for={{card, params} <- cards_in_order(cards)} id={card} phx-click="toggle_card"
-            phx-value-card={card} class={card_button_class(params)} phx-hook="CardButton">
+        <button phx-no-format :for={{card, params} <- cards_in_order(cards)} id={card}
+            phx-click={JS.dispatch("toggle_card", detail: %{avatar: @avatar, colour: @colour}) |> JS.push("toggle_card",
+            value: %{card: card})}
+            data-selected={params.selected && "true" || "false"}
+            phx-value-card={card}
+            class={card_button_class(params)}
+            phx-hook="CardButton">
             <.tooltip :if={params.selected} class={["px-4 py-2 font-medium text-black bg-card border-2 rounded-md",
-                border_colour_from_bg_colour(params.colour)]}>
-                Anonymous {avatar_name(params.avatar)} {if(params.avatar == @avatar, do: "(You)")}
+                border_colour_from_bg_colour(params[:colour])]}>
+                Anonymous {avatar_name(params[:avatar])} {if(params[:avatar] == @avatar, do: "(You)")}
             </.tooltip>
             <p id={"card-button-text-#{card}"} class="w-full h-full flex flex-wrap content-center justify-center">{card}
             </p>


### PR DESCRIPTION
When user clicks on a card, if they're not near to a server (and without optimistic UI updating), there's latency between the click and the card being highlighted. This adds optimistic updates so that the card is highlighted client-side and then the server ensures the move was legal and sends the _actual_ game state back down to the client.